### PR TITLE
Missing PHP close-file tag.

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -7,3 +7,5 @@ outn(_("dropping table queuemetrics.."));
 sql('DROP TABLE IF EXISTS `queuemetrics_options`');
 out(_("done"));
 
+?>
+


### PR DESCRIPTION
I noticed that the PHP EOF tag was missing from the uninstall file, so I'm fixing it.
